### PR TITLE
fix: process_image_array leaks GPU/CPU memory outside the CLI wrapper

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import untextre.consensus as consensus_mod
+import untextre.detector as detector_mod
 import untextre.metrics as metrics_mod
 import untextre.pipeline as pipeline_mod
 import untextre.preprocessor as preprocessor_mod
@@ -207,6 +208,64 @@ class TestProcessImageArray:
         )
 
         assert captured["use_budgeted_expand"] is True
+
+    def test_cleanup_vram_runs_on_success(self, monkeypatch):
+        """process_image_array sweeps GPU/CPU memory on a normal return.
+
+        Detection already self-cleans (consensus.run_consensus_detection calls
+        cleanup_vram); this is the matching guarantee on the caller-facing
+        entry point, so every caller gets it without wrapping the call
+        themselves (#33).
+        """
+        image = np.ones((40, 80, 3), dtype=np.uint8) * 200
+        monkeypatch.setattr(preprocessor_mod, "preprocess_image", lambda _img: image.copy())
+        monkeypatch.setattr(metrics_mod, "needs_retry", lambda _region: False)
+        monkeypatch.setattr(
+            pipeline_mod,
+            "_generate_masks_and_inpaint",
+            lambda img, boxes, _g, _method, _target, **_kw: (
+                np.zeros(img.shape[:2], dtype=np.uint8),
+                img.copy(),
+            ),
+        )
+        calls = []
+        monkeypatch.setattr(detector_mod, "cleanup_vram", lambda: calls.append("cleanup"))
+
+        process_image_array(
+            image,
+            method="telea",
+            forced_bbox=(12, 8, 24, 16),
+            auto_retry=False,
+        )
+
+        assert calls == ["cleanup"]
+
+    def test_cleanup_vram_runs_even_when_pipeline_raises(self, monkeypatch):
+        """A mid-pipeline exception must not skip the memory sweep.
+
+        Before #33's fix, nothing in the call chain wrapped inpainting in a
+        try/finally at all, so an exception left GPU/CPU memory dangling with
+        no cleanup whatsoever.
+        """
+        image = np.ones((40, 80, 3), dtype=np.uint8) * 200
+        monkeypatch.setattr(preprocessor_mod, "preprocess_image", lambda _img: image.copy())
+
+        def boom(img, boxes, _g, _method, _target, **_kw):
+            raise RuntimeError("inpaint exploded")
+
+        monkeypatch.setattr(pipeline_mod, "_generate_masks_and_inpaint", boom)
+        calls = []
+        monkeypatch.setattr(detector_mod, "cleanup_vram", lambda: calls.append("cleanup"))
+
+        with pytest.raises(RuntimeError, match="inpaint exploded"):
+            process_image_array(
+                image,
+                method="telea",
+                forced_bbox=(12, 8, 24, 16),
+                auto_retry=False,
+            )
+
+        assert calls == ["cleanup"]
 
 
 class TestProcessSingleImageFailovers:

--- a/untextre/pipeline.py
+++ b/untextre/pipeline.py
@@ -373,6 +373,61 @@ def process_image_array(
 
     Returns:
         PipelineResult containing cleaned image, mask, timings, and consensus boxes.
+
+    GPU/CPU memory is reclaimed via cleanup_vram() on every exit path (normal
+    return, early skip, or exception) so callers never have to remember to wrap
+    this themselves -- see #33. Detection already self-cleans in
+    consensus.run_consensus_detection(); this closes the matching gap on the
+    inpainting side.
+    """
+    from .detector import cleanup_vram
+
+    try:
+        return _process_image_array_impl(
+            image,
+            image_name=image_name,
+            target_color=target_color,
+            method=method,
+            mask=mask,
+            confidence_threshold=confidence_threshold,
+            granularity=granularity,
+            forced_bbox=forced_bbox,
+            color_sensitivity=color_sensitivity,
+            expand_bboxes=expand_bboxes,
+            auto_retry=auto_retry,
+            use_grabcut=use_grabcut,
+            use_grabcut_expand=use_grabcut_expand,
+            use_budgeted_expand=use_budgeted_expand,
+            coverage_limit=coverage_limit,
+            mask_config=mask_config,
+        )
+    finally:
+        cleanup_vram()
+
+
+def _process_image_array_impl(
+    image: np.ndarray,
+    *,
+    image_name: str = "<memory>",
+    target_color: Optional[tuple] = None,
+    method: str = "lama",
+    mask: Optional[np.ndarray] = None,
+    confidence_threshold: float = CLI_DEFAULT_CONFIDENCE,
+    granularity: Optional[int] = None,
+    forced_bbox: Optional[tuple] = None,
+    color_sensitivity: int = 3,
+    expand_bboxes: bool = True,
+    auto_retry: bool = True,
+    use_grabcut: bool = False,
+    use_grabcut_expand: bool = False,
+    use_budgeted_expand: bool = False,
+    coverage_limit: float = 0.06,
+    mask_config: Optional[dict] = None,
+) -> PipelineResult:
+    """Pipeline body for process_image_array; see that function's docstring.
+
+    Not part of the public API -- callers should always go through
+    process_image_array so the memory cleanup in its finally: block applies.
     """
     from .preprocessor import preprocess_image
     from .consensus import run_consensus_detection


### PR DESCRIPTION
Fixes #33.

**Root cause:** `consensus.run_consensus_detection()` calls `cleanup_vram()` (`gc.collect()` + `torch.cuda.empty_cache()` + `torch.cuda.synchronize()`) after every detection pass. Nothing equivalent ran after the *inpainting* phase inside `pipeline.py` itself — `LamaInpainter.inpaint()` only did `empty_cache()` (no `gc.collect()`), and that was the only cleanup on the inpainting side, period.

`cli.py`'s main loop papered over this with its own per-image `finally:` block calling `cleanup_vram()`. Every *other* caller — `streamlit_app.py`, `synthetic_text_benchmark.py`, `test_generated_text_benchmark.py`'s Monte Carlo benchmark — goes through `process_image_array` directly with no such wrapper. Confirmed live: a Streamlit session left running ~3 days was still holding ~538MB VRAM with zero active work. The Monte Carlo benchmark reproduces it under load: 12 sequential cases in one process with no per-case reset compound into a real `CUDA error: out of memory` plus cascading system-RAM `MemoryError`s.

**Fix:** split `process_image_array` into a thin public wrapper (identical signature, docstring, and behavior) that calls the renamed `_process_image_array_impl` inside `try/finally`, with `cleanup_vram()` in the `finally:` clause. Covers every exit path — normal return, the early "no text detected" skip, *and* exceptions raised anywhere inside the pipeline — instead of only the paths a caller happened to wrap.

**Tests:** 2 new regression tests (`test_cleanup_vram_runs_on_success`, `test_cleanup_vram_runs_even_when_pipeline_raises`) proving cleanup fires on both a normal return and a mid-pipeline exception. Verified genuinely red before green: both fail cleanly against the pre-fix code (checked via `git stash`), pass against the fix. Full suite: 96 tests across pipeline/inpaint/detector_unit/lama_inpainter/consensus, all green. `ruff check` clean. `basedpyright` shows the same 4 pre-existing errors from #2 (just shifted ~55 lines by the insertion), 0 new.

All existing callers (`cli.py`, `streamlit_app.py`, `pipeline.process_single_image`, `synthetic_text_benchmark.py`, every test call site) are unaffected — `process_image_array`'s signature didn't change.