### PR TITLE
fix: propagate CIEDE2000 delta-E to the generated-text benchmark

### DIFF
--- a/scripts/run_inpaint_eval.py
+++ b/scripts/run_inpaint_eval.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 import cv2
 import numpy as np
-from skimage.color import deltaE_ciede2000
 from skimage.metrics import structural_similarity
 
+from untextre.color_metrics import delta_e
 from untextre.inpaint import inpaint_image
 from untextre.mask_experiments import DEFAULT_MANIFEST, load_manifest_cases, truth_target_mask
 
@@ -52,8 +52,8 @@ def evaluate_case(case: dict, config_id: str, method: str) -> dict:
 
     before_ssim = _ssim(before, target)
     after_ssim = _ssim(after, target)
-    before_de = _delta_e(before, target)
-    after_de  = _delta_e(after, target)
+    before_de = delta_e(before, target)
+    after_de  = delta_e(after, target)
     return {
         "case_id": case["id"],
         "config_id": config_id,
@@ -85,20 +85,6 @@ def _ssim(a: np.ndarray, b: np.ndarray) -> float:
     if win_size < 3:
         return 1.0 if np.array_equal(a, b) else 0.0
     return float(structural_similarity(a, b, channel_axis=2, win_size=win_size))
-
-
-def _bgr_to_lab_cie(img: np.ndarray) -> np.ndarray:
-    """Convert uint8 BGR to CIE L*a*b* in standard ranges (L*∈[0,100], a*/b*∈[-128,127])."""
-    raw = cv2.cvtColor(img, cv2.COLOR_BGR2LAB).astype(np.float32)
-    raw[..., 0] *= 100.0 / 255.0   # L: OpenCV [0,255] → CIE [0,100]
-    raw[..., 1] -= 128.0            # a: OpenCV [0,255] → CIE [-128,127]
-    raw[..., 2] -= 128.0            # b: OpenCV [0,255] → CIE [-128,127]
-    return raw
-
-
-def _delta_e(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean per-pixel CIE ΔE₀₀ between two uint8 BGR images."""
-    return float(np.mean(deltaE_ciede2000(_bgr_to_lab_cie(a), _bgr_to_lab_cie(b))))
 
 
 def _gain_ratio(gain: float, possible: float) -> float:

--- a/tests/test_generated_text_benchmark.py
+++ b/tests/test_generated_text_benchmark.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 from skimage.metrics import structural_similarity as ssim
 
+from untextre.color_metrics import masked_delta_e
 from untextre.inpaint import initialize_lama_model
 from untextre.pipeline import MASK_MODE_CHOICES, initialize_consensus_models, mask_mode_options, process_image_array
 from untextre.synthetic_text_benchmark import (
@@ -56,13 +57,6 @@ def _masked_ssim_score(before: np.ndarray, after: np.ndarray, mask: np.ndarray) 
     return float(np.mean(ssim_map[mask.astype(bool)]))
 
 
-def _masked_lab_mae(before: np.ndarray, after: np.ndarray, mask: np.ndarray) -> float:
-    before_lab = (cv2.cvtColor(before, cv2.COLOR_BGR2LAB) // 16) * 16
-    after_lab = (cv2.cvtColor(after, cv2.COLOR_BGR2LAB) // 16) * 16
-    diff = np.abs(before_lab.astype(np.int16) - after_lab.astype(np.int16))
-    return float(diff[mask.astype(bool)].mean())
-
-
 def _classify_outcome(
     *,
     consensus_boxes: list[tuple[int, int, int, int]],
@@ -97,9 +91,9 @@ def _row_summary(rows: list[dict]) -> str:
             )
         )
         parts.append(
-            "lab_mae_delta mean={:.6f} median={:.6f}".format(
-                statistics.fmean(row["lab_mae_delta"] for row in repaired),
-                statistics.median(row["lab_mae_delta"] for row in repaired),
+            "delta_e_delta mean={:.6f} median={:.6f}".format(
+                statistics.fmean(row["delta_e_delta"] for row in repaired),
+                statistics.median(row["delta_e_delta"] for row in repaired),
             )
         )
     return "; ".join(parts)
@@ -189,14 +183,14 @@ def test_generated_text_monte_carlo_benchmark(
             repaired_ssim = _masked_ssim_score(
                 synthetic.clean, pipeline_result.image, synthetic.truth_mask
             )
-            baseline_lab = _masked_lab_mae(
+            baseline_de = masked_delta_e(
                 synthetic.clean, synthetic.watermarked, synthetic.truth_mask
             )
-            repaired_lab = _masked_lab_mae(
+            repaired_de = masked_delta_e(
                 synthetic.clean, pipeline_result.image, synthetic.truth_mask
             )
             row["ssim_delta"] = repaired_ssim - baseline_ssim
-            row["lab_mae_delta"] = baseline_lab - repaired_lab
+            row["delta_e_delta"] = baseline_de - repaired_de
         rows.append(row)
 
         if save_images_dir is not None:

--- a/untextre/color_metrics.py
+++ b/untextre/color_metrics.py
@@ -1,0 +1,38 @@
+"""Shared CIE color-distance helpers for offline quality evaluation.
+
+Not used by the production pipeline -- these back the benchmark/eval scripts
+and tests that score repair quality against a known-clean ground truth
+(`scripts/run_inpaint_eval.py`, `tests/test_generated_text_benchmark.py`).
+Centralized here so a metric change (e.g. LAB-MAE -> CIEDE2000 delta-E)
+propagates to every consumer instead of drifting between copies.
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from skimage.color import deltaE_ciede2000
+
+
+def bgr_to_lab_cie(img: np.ndarray) -> np.ndarray:
+    """Convert uint8 BGR to CIE L*a*b* in standard ranges (L*∈[0,100], a*/b*∈[-128,127])."""
+    raw = cv2.cvtColor(img, cv2.COLOR_BGR2LAB).astype(np.float32)
+    raw[..., 0] *= 100.0 / 255.0  # L: OpenCV [0,255] -> CIE [0,100]
+    raw[..., 1] -= 128.0  # a: OpenCV [0,255] -> CIE [-128,127]
+    raw[..., 2] -= 128.0  # b: OpenCV [0,255] -> CIE [-128,127]
+    return raw
+
+
+def delta_e_map(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Per-pixel CIE ΔE₀₀ between two uint8 BGR images, same shape as the input."""
+    return deltaE_ciede2000(bgr_to_lab_cie(a), bgr_to_lab_cie(b))
+
+
+def delta_e(a: np.ndarray, b: np.ndarray) -> float:
+    """Mean per-pixel CIE ΔE₀₀ between two uint8 BGR images."""
+    return float(np.mean(delta_e_map(a, b)))
+
+
+def masked_delta_e(a: np.ndarray, b: np.ndarray, mask: np.ndarray) -> float:
+    """Mean per-pixel CIE ΔE₀₀ between two uint8 BGR images, restricted to mask."""
+    return float(delta_e_map(a, b)[mask.astype(bool)].mean())


### PR DESCRIPTION
`scripts/run_inpaint_eval.py` already moved from raw LAB-MAE to proper CIE ΔE₀₀ (`skimage.color.deltaE_ciede2000`) in an earlier patch, but that change never propagated. `tests/test_generated_text_benchmark.py` still used the old quantized-LAB mean-absolute-error metric (`_masked_lab_mae`) — and there's a third copy of the same old approach in `tests/test_u_mode_integration.py` that I left untouched (flagging for a follow-up rather than silently expanding scope).

**Fix:** extracted the shared conversion + metric into `untextre/color_metrics.py` (`bgr_to_lab_cie`, `delta_e`, `delta_e_map`, `masked_delta_e`) so there's one source of truth instead of copies that can drift again — the actual root cause of "didn't propagate." `run_inpaint_eval.py` now imports `delta_e` from there instead of defining its own `_bgr_to_lab_cie`/`_delta_e` (output schema unchanged: still `delta_e_before`/`delta_e_after`/`delta_e_gain_ratio`, verified via `test_mask_experiment_scripts.py`). `test_generated_text_benchmark.py`'s `_masked_lab_mae` is gone; baseline/repaired comparisons use `masked_delta_e`, and the row field renamed `lab_mae_delta` -> `delta_e_delta` (same improvement-positive polarity: `baseline - repaired`).

**Ran the actual benchmark** (real GPU, LaMa loaded successfully this run) to get real numbers: 12 cases, 11 repaired / 1 miss. `ssim_delta` mean=0.663, median=0.728 (SSIM recovered substantially post-repair). `delta_e_delta` mean=16.51, median=17.36 (mean CIEDE2000 color error dropped by ~16.5 ΔE units after repair — for reference, ΔE<2 is barely perceptible and ΔE>10 is clearly perceptible, so this reflects a real, substantial visible-quality recovery, not noise).

**Tests:** `test_mask_experiment_scripts.py` (15 passed, 1 skipped) confirms `run_inpaint_eval.py`'s output schema is untouched. `ruff` clean, `basedpyright` clean on the new module.