### PR TITLE
refactor: TimingReportConfig for _save_clean_timing_report (#7)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,12 @@
 This file tracks current problems in the codebase. It should not duplicate the
 README or preserve old completed review notes.
 
+**Source of truth:** the GitHub issue tracker (epic #31) is authoritative for
+scope, priority, and status. Entries below that map to an open issue carry an
+`(#N)` reference — check the issue, not this file, for current status. When an
+issue closes, remove or check off the matching entry here in the same commit
+so this file never drifts from the tracker.
+
 ## Should Fix
 
 - [x] **Lowe ratio-test citation**: Add a Lowe (2004) citation comment to the `0.75`
@@ -34,10 +40,6 @@ README or preserve old completed review notes.
 - [x] **preprocessor.py dead alias**: Remove `result_img = image` alias; write
   `cv2.cvtColor(image, ...)` directly. `(preprocessor.py:44)`
 
-- [ ] **preprocessor.py CLAHE/bilateral citation**: Update the module docstring and
-  inline comments to name the dataset and define the FOM metric for the grid-search
-  result. `(preprocessor.py:52-57)`
-
 - [x] **morph_clean_mask dead bbox param**: Remove the unused `bbox: BBox` parameter
   from `morph_clean_mask` and update all call sites. `(mask_generator.py:27)`
 
@@ -56,137 +58,61 @@ README or preserve old completed review notes.
 - [x] **Consensus padding label**: Add `# EMPIRICAL` label to the 10%-per-side
   padding constant. `(consensus.py:397-417)`
 
-- [ ] **process_with_known_mask API**: Document (or add a `WatermarkTemplate`
+- [ ] **process_with_known_mask API** (#8): Document (or add a `WatermarkTemplate`
   overload to) `process_with_known_mask` so batch callers are not forced into
   O(N×templates) ORB extraction. `(orb_matcher.py:93)`
-
-- [ ] **TELEA radius configurable**: Decide whether the TELEA inpaint radius (`3`)
-  should be a CLI option, pipeline parameter, or documented constant with an
-  `# EMPIRICAL` label. `(inpaint.py:338)`
-
-- [ ] **Inpainting-context dilation**: Document why `64px` is the right dilation
-  for LaMa context, or make it configurable. Current comment is a TODO with no
-  derivation. `(inpaint.py:404)`
 
 ---
 
 ## Backlog
 
-- [ ] **Defensive copy in preprocessing**: Add a comment documenting the no-mutation
-  assumption in `preprocess_image`; add `.copy()` at next refactor if the chain
-  gains any in-place step. `(pipeline.py:329)`
-
-- [ ] **Triple color-enhance consolidation**: Consolidate the three sequential
+- [ ] **Triple color-enhance consolidation** (#11): Consolidate the three sequential
   `_try_color_enhanced_detection` invocations into a single helper that tries all
   colors in one pass with early exit. `(pipeline.py:87-121)`
 
-- [ ] **Color enhancement comment accuracy**: Rewrite the "converting [color] to
-  black" comment to accurately describe CLAHE-on-contrast-enhanced-grayscale as
-  the working mechanism. `(pipeline.py:359-366)`
-
-- [ ] **coverage_limit call-site label**: Add a brief `# EMPIRICAL` inline note at
-  the `coverage_limit=0.06` default argument. `(pipeline.py:123-225)`
-
-- [ ] **force_output double-load**: When `image is not None` in the `force_output`
+- [ ] **force_output double-load** (#10): When `image is not None` in the `force_output`
   path, use the already-loaded image instead of reloading from disk. Requires a
   conditional (not a one-line swap — `image` is `None` in the no-templates path).
   `(cli.py:254-260)`
 
-- [ ] **8-parameter report signature**: Refactor `_save_clean_timing_report` to take
-  a config dict for its optional `target_color` and `forced_bbox` parameters.
-  `(reports.py:51)`
-
-- [ ] **Detector position filtering**: Convert the position-based filtering TODO to
-  a tracked issue and remove the in-code placeholder. Either implement with tests
-  and documented evidence, or remove it. `(detector.py:685)`
-
-- [ ] **EAST inner loop vectorization**: Vectorize the pure-Python trig loop in
-  `_decode_east_predictions` using numpy slice operations. `(detector.py:438-473)`
-
-- [ ] **LaMa health check cost**: Replace the full forward-pass health check with a
+- [ ] **LaMa health check cost** (#17): Replace the full forward-pass health check with a
   cheaper attribute-existence check. `(inpaint.py:47-78)`
 
-- [ ] **Inlier count in timing dict**: Propagate the ORB inlier count into the timing
+- [ ] **Inlier count in timing dict** (#13): Propagate the ORB inlier count into the timing
   dict so reports can distinguish marginal from strong matches. `(known_mask.py:78)`
 
-- [ ] **load_checkpoint no-op**: Replace `load_checkpoint = load_checkpoint` with an
-  explanatory comment. `(lama_inpainter.py:43)`
-
-- [ ] **Defer CUDA synchronize to batch loop**: Move `torch.cuda.synchronize()` from
-  per-image to per-batch in `cli.py`. `(lama_inpainter.py:317-320)`
-
-- [ ] **3D boolean mask allocation**: Replace the H×W×3 boolean mask in
+- [ ] **3D boolean mask allocation** (#15): Replace the H×W×3 boolean mask in
   surrounding-region extraction with index-based logic. `(find_text_colors.py:440-442)`
 
-- [ ] **Double ORB extraction in discovery**: Change `_candidate_meets_consensus_minimums`
+- [ ] **Double ORB extraction in discovery** (#14): Change `_candidate_meets_consensus_minimums`
   to return pre-built variants instead of discarding them. `(orb_prep.py:159-161)`
 
-- [ ] **Silent metadata drop on save**: Add `logger.debug` when `save_image` falls
-  through from Pillow to `cv2.imwrite`, noting that ICC profile and DPI are dropped.
-  `(utils.py:321-332)`
-
-- [ ] **build_final_templates output size**: Confirm that `O(clusters) + O(records)`
-  output in `build_final_templates` is intentional (cascade design) and add a comment
-  explaining the intent. `(watermark_consensus.py:1442-1451)`
-
-- [ ] **Shape metrics are measured but not part of production FOM**: `metrics.py`
-  provides `measure_blackhat_energy()` and `measure_edge_row_energy()`, but
-  `find_mask_by_spatial_tf_idf()` still selects clusters using TF-IDF, border ratio,
-  and connected-component fraction only. Evaluate whether these metrics improve mask
-  quality before adding them to the scoring path.
-
-- [ ] **Direct CRAFT detector diversification**: Consider adding a direct CRAFT pass
+- [ ] **Direct CRAFT detector diversification** (#25): Consider adding a direct CRAFT pass
   alongside EasyOCR. EasyOCR already uses OCR-oriented detection internally, but a
   standalone CRAFT detector may expose different boxes/thresholds for cursive,
   curved, or fragmented text and reduce detector misses.
 
-- [ ] **DB++ detector diversification**: Consider adding DB++ via PaddleOCR or an
-  available DocTR variant alongside the current DocTR DBNet detector. Validate that
-  its errors are independent enough to improve consensus before accepting the
-  dependency/runtime cost.
-
-- [ ] **YOLOv8 watermark-detector tryout**: Benchmark
+- [ ] **YOLOv8 watermark-detector tryout** (#22): Benchmark
   [`mnemic/watermarks_yolov8`](https://huggingface.co/mnemic/watermarks_yolov8)
-  against the current EAST/DocTR/EasyOCR panel on (a) the zero-corpus FP baseline
+  against the current EAST/EasyOCR/YOLO11x panel on (a) the zero-corpus FP baseline
   (`tests/images/zero_detector_fp_baseline/`) and (b) the synthetic watermark
   benchmark, measuring recall, FP rate, and per-image latency. Unlike the panel,
   it is watermark-specific rather than text-generic, so it may catch logo marks
   the text detectors miss. If it dominates the slowest/least-accurate panel
   member, give it that seat; validate error independence before changing the
-  2-of-3 consensus rule.
+  2-of-N consensus rule.
 
-- [ ] **Replace DocTR with YOLO11x in production consensus panel**: Ready-to-implement
-  ticket at `docs/superpowers/specs/2026-07-07-replace-doctr-with-yolo11x.md`. Known-truth
-  simulation of the actual production `find_consensus_boxes` algorithm (415-pair corpus)
-  shows the swap improves recall 92.3%->96.1%, cuts false-positive incidents 3.6%->2.7%,
-  cuts masked FP area 0.018%->0.015%, and cuts detector wall-clock ~5x (DocTR is 68x
-  slower than YOLO11x per image). Every axis improves; no tradeoff. Reproduce with
-  `scripts/simulate_production_consensus_swap.py`.
-
-- [ ] **DocTR receives BGR input on the normal path**: `detector.py:599` feeds
-  `load_image`'s BGR array straight into the DocTR predictor (trained on RGB);
-  EAST (`swapRB=True`) and EasyOCR (`BGR2RGB`) both convert explicitly. A/B test
-  (2026-07-06, 6 synthetic vivid-text cases + 6 real flagged photos, script at
-  `.codex-tmp/doctr_ab/run_ab.py`) showed detection differences within noise:
-  6/6 truth hits both arms, confidence deltas < 0.03, one threshold-straddling
-  box flicker. DELIBERATELY left unchanged to keep the frozen FP baseline
-  consistent (a KNOWN QUIRK comment now marks the call site). Revisit if DocTR
-  is ever used for recognition (color-sensitive) or when thresholds are next
-  recalibrated. The misleading signposts are fixed (2026-07-06): the
-  preprocessor docstring now states the BGR-convention R==G==B contract, and
-  the GRAY2RGB/GRAY2BGR alias confusion is documented at the conversion site.
-
-- [ ] **CLIP/ViT semantic bbox adjudication**: Consider scoring detector-proposed
+- [ ] **CLIP/ViT semantic bbox adjudication** (#28): Consider scoring detector-proposed
   bbox crops with a lightweight OpenCLIP ViT (`ViT-B-32`/`ViT-B-16`) against prompt
   axes such as text/logo/URL vs natural texture/clothing/grass/backdrop. Use the
   scores as voting/deconfliction features, not as a standalone detector, and validate
   whether they separate true overlay text from structured-background false positives.
 
-- [ ] **Output-quality regression coverage is still indirect**: The suite has strong
+- [ ] **Output-quality regression coverage is still indirect** (#21): The suite has strong
   unit/workflow coverage but few image-in/image-out assertions for final visual quality.
   Add focused regression tests around known failure cases.
 
-- [ ] **Promote has-text-2 bbox harvest into bbox/blob-selection tests**:
+- [ ] **Promote has-text-2 bbox harvest into bbox/blob-selection tests** (#19):
   `tests/images/has_text_2_pipeline_bbox_harvest/` contains a completed 405-image
   full-pipeline bbox-of-record harvest with review slots and overlays. It has strong
   candidates for bbox optimization and blob selection: 145 ambiguous cases, 58

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 
 from untextre.reports import (
+    TimingReportConfig,
     _save_clean_timing_report,
     _save_discovered_watermark_candidates,
 )
@@ -69,8 +70,8 @@ class TestSaveCleanTimingReport:
         out_file = tmp_path / "report.txt"
         _save_clean_timing_report(
             [timing], total_time=2.5, avg_time=2.5,
-            timing_file=out_file, method="lama",
-            confidence_threshold=0.3, target_color=None, forced_bbox=None,
+            timing_file=out_file,
+            config=TimingReportConfig(method="lama", confidence_threshold=0.3),
         )
         text = out_file.read_text()
 
@@ -86,8 +87,8 @@ class TestSaveCleanTimingReport:
         out_file = tmp_path / "report.txt"
         _save_clean_timing_report(
             timings, total_time=6.0, avg_time=3.0,
-            timing_file=out_file, method="telea",
-            confidence_threshold=0.3, target_color=None, forced_bbox=None,
+            timing_file=out_file,
+            config=TimingReportConfig(method="telea", confidence_threshold=0.3),
         )
         text = out_file.read_text()
 
@@ -105,8 +106,8 @@ class TestSaveCleanTimingReport:
         out_file = tmp_path / "report.txt"
         _save_clean_timing_report(
             timings, total_time=10.0, avg_time=2.0,
-            timing_file=out_file, method="lama",
-            confidence_threshold=0.3, target_color=None, forced_bbox=None,
+            timing_file=out_file,
+            config=TimingReportConfig(method="lama", confidence_threshold=0.3),
         )
         text = out_file.read_text()
 
@@ -126,8 +127,8 @@ class TestSaveCleanTimingReport:
         out_file = tmp_path / "report.txt"
         _save_clean_timing_report(
             [timing], total_time=1.0, avg_time=1.0,
-            timing_file=out_file, method="lama",
-            confidence_threshold=0.3, target_color=None, forced_bbox=None,
+            timing_file=out_file,
+            config=TimingReportConfig(method="lama", confidence_threshold=0.3),
         )
         text = out_file.read_text()
         assert "N/A" in text
@@ -137,10 +138,13 @@ class TestSaveCleanTimingReport:
         out_file = tmp_path / "report.txt"
         _save_clean_timing_report(
             [timing], total_time=1.0, avg_time=1.0,
-            timing_file=out_file, method="lama",
-            confidence_threshold=0.3,
-            target_color=(128, 128, 128),
-            forced_bbox=(10, 20, 100, 50),
+            timing_file=out_file,
+            config=TimingReportConfig(
+                method="lama",
+                confidence_threshold=0.3,
+                target_color=(128, 128, 128),
+                forced_bbox=(10, 20, 100, 50),
+            ),
         )
         text = out_file.read_text()
         assert "Target color: (128, 128, 128)" in text
@@ -154,8 +158,8 @@ class TestSaveCleanTimingReport:
         out_file = tmp_path / "report.txt"
         _save_clean_timing_report(
             timings, total_time=5.0, avg_time=2.5,
-            timing_file=out_file, method="lama",
-            confidence_threshold=0.3, target_color=None, forced_bbox=None,
+            timing_file=out_file,
+            config=TimingReportConfig(method="lama", confidence_threshold=0.3),
         )
         text = out_file.read_text()
         assert "retried with g=8: 1" in text
@@ -171,8 +175,8 @@ class TestSaveCleanTimingReport:
         out_file = tmp_path / "report.txt"
         _save_clean_timing_report(
             [template_only], total_time=1.0, avg_time=1.0,
-            timing_file=out_file, method="lama",
-            confidence_threshold=0.3, target_color=None, forced_bbox=None,
+            timing_file=out_file,
+            config=TimingReportConfig(method="lama", confidence_threshold=0.3),
         )
         text = out_file.read_text()
         assert "watermarked_photo.jpg" in text or "watermarked_photo" in text
@@ -190,8 +194,8 @@ class TestSaveCleanTimingReport:
         out_file = tmp_path / "report.txt"
         _save_clean_timing_report(
             [consensus, template_only], total_time=2.5, avg_time=1.25,
-            timing_file=out_file, method="telea",
-            confidence_threshold=0.3, target_color=None, forced_bbox=None,
+            timing_file=out_file,
+            config=TimingReportConfig(method="telea", confidence_threshold=0.3),
         )
         text = out_file.read_text()
         assert "consensus.png" in text

--- a/untextre/cli.py
+++ b/untextre/cli.py
@@ -275,15 +275,21 @@ def main() -> None:
     
     # Detailed timing report if requested
     if args.timing and detailed_timings:
+        timing_config = reports.TimingReportConfig(
+            method=args.paint,
+            confidence_threshold=args.confidence_threshold,
+            target_color=target_color,
+            forced_bbox=forced_bbox,
+        )
         # Always save timing report to a clean file
         timing_file = output_path / "timing_report.txt"
-        reports._save_clean_timing_report(detailed_timings, total_time, avg_time, timing_file, args.paint, args.confidence_threshold, target_color, forced_bbox)
+        reports._save_clean_timing_report(detailed_timings, total_time, avg_time, timing_file, timing_config)
         logger.info(f"Timing report saved to: {timing_file}")
         
         # Also save to logfile location if specified
         if args.logfile:
             log_timing_file = Path(args.logfile).with_suffix('.timing.txt')
-            reports._save_clean_timing_report(detailed_timings, total_time, avg_time, log_timing_file, args.paint, args.confidence_threshold, target_color, forced_bbox)
+            reports._save_clean_timing_report(detailed_timings, total_time, avg_time, log_timing_file, timing_config)
             logger.info(f"Timing report also saved to: {log_timing_file}")
 
 

--- a/untextre/reports.py
+++ b/untextre/reports.py
@@ -1,6 +1,7 @@
 """Reporting helpers for CLI and watermark discovery outputs."""
 
 import statistics
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
@@ -48,19 +49,35 @@ def _save_discovered_watermark_candidates(
     return watermark_templates
 
 
-def _save_clean_timing_report(detailed_timings: list, total_time: float, avg_time: float, timing_file: Path, method: str, confidence_threshold: float, target_color: Optional[tuple], forced_bbox: Optional[tuple]) -> None:
+@dataclass(frozen=True)
+class TimingReportConfig:
+    """Per-run metadata for a timing report; optional fields are display-only."""
+
+    method: str
+    confidence_threshold: float
+    target_color: Optional[tuple] = None
+    forced_bbox: Optional[tuple] = None
+
+
+def _save_clean_timing_report(
+    detailed_timings: list,
+    total_time: float,
+    avg_time: float,
+    timing_file: Path,
+    config: TimingReportConfig,
+) -> None:
     """Save a clean timing report to file without duplicate logging."""
     with open(timing_file, 'w') as f:
         f.write("=" * 74 + "\n")
         f.write("CONSENSUS DETECTION + SPATIAL TF-IDF TIMING REPORT\n")
         f.write("=" * 74 + "\n")
-        f.write(f"Confidence threshold: {confidence_threshold}\n")
+        f.write(f"Confidence threshold: {config.confidence_threshold}\n")
         f.write("TF-IDF granularity: g=4 (auto-retry with g=8 if needed)\n")
-        f.write(f"Inpainting method: {method}\n")
-        if target_color:
-            f.write(f"Target color: {target_color}\n")
-        if forced_bbox:
-            f.write(f"Forced bbox: {forced_bbox}\n")
+        f.write(f"Inpainting method: {config.method}\n")
+        if config.target_color:
+            f.write(f"Target color: {config.target_color}\n")
+        if config.forced_bbox:
+            f.write(f"Forced bbox: {config.forced_bbox}\n")
         
         # Count retries and expansions
         retried_count = sum(1 for t in detailed_timings if t.get('retried_with_g8', False))


### PR DESCRIPTION
Closes #7.

## Change
`_save_clean_timing_report` took 8 positional parameters, two of them
optional (`target_color`, `forced_bbox`) that every caller had to pass
explicitly. Replaced with a `TimingReportConfig` frozen dataclass
(`method`, `confidence_threshold`, `target_color=None`, `forced_bbox=None`);
the function now takes `(detailed_timings, total_time, avg_time, timing_file, config)`.

- `cli.py`'s two call sites build one `TimingReportConfig` per run and reuse it.
- `tests/test_reports.py`'s 7 call sites updated to construct the config.
- `tests/test_cli.py` mocks the function with `*args, **kwargs`, so it needed no change.

## Verification
- `uv run ruff check untextre/reports.py untextre/cli.py tests/test_reports.py tests/test_cli.py` — clean
- `uv run pytest tests/test_reports.py tests/test_cli.py -m "not slow"` — 22 passed
- `uv run pytest -m "not slow"` — 366 passed, 2 skipped (1 unrelated `cv2.phaseCorrelate` OOM flake in `test_watermark_consensus.py`, confirmed passing in isolation, pre-existing local memory pressure — not touched by this diff)
- `uv run basedpyright untextre/reports.py untextre/cli.py` — no new errors (the sole error, `cli.py:245` `detailed_timings.append` on `Optional[list]`, pre-exists and is in scope for #2, not this ticket)

## Second commit: TODO.md reconciliation
While touching this, found `TODO.md` had drifted from the issue tracker — several
entries referenced work already merged (#6, #9, #12, #16) or already-made decisions
(#27, closed wontfix), and others described states the epic #31 audit had already
confirmed true in code. Reconciled it in a separate commit: removed stale/completed
entries, added `(#N)` references to surviving items with an open issue, and noted
the issue tracker as the source of truth at the top of the file. No source changes
in that commit.