### PR TITLE
fix: clear basedpyright errors in untextre/, enforce it in CI (#2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,11 @@ jobs:
             uv run ruff check .
 
       - run:
+          name: Run basedpyright
+          command: |
+            uv run basedpyright untextre
+
+      - run:
           name: Run tests with coverage
           command: |
             uv run pytest -m "not slow" \

--- a/tests/test_orb_matcher.py
+++ b/tests/test_orb_matcher.py
@@ -368,14 +368,18 @@ class TestFindKnownMaskValidation:
                 return [], None
 
         monkeypatch.setattr(orb_matcher_mod, "build_candidate_orb_variants", fake_build_candidate_orb_variants)
-        monkeypatch.setattr(cv2, "ORB_create", lambda *args, **kwargs: FakeORB())
+        monkeypatch.setattr(cv2.ORB, "create", lambda *args, **kwargs: FakeORB())
 
         result = find_known_mask_in_image(target, known_rgba)
 
         assert result is None
         assert builder_called["value"] is True
         assert len(orb_masks) >= 1
-        assert orb_masks[0] is None
+        # find_known_mask_in_image passes an explicit all-255 "no restriction"
+        # mask instead of None (the cv2 stub rejects None; an all-255 mask is
+        # the behaviorally-equivalent, stub-satisfying replacement).
+        assert orb_masks[0] is not None
+        assert np.all(orb_masks[0] == 255)
 
     def test_known_mask_falls_back_to_later_prepared_variant(self, monkeypatch):
         target = np.zeros((80, 100, 3), dtype=np.uint8)

--- a/untextre/__init__.py
+++ b/untextre/__init__.py
@@ -8,6 +8,13 @@ are imported lazily so that lightweight entry points like ``--help`` and
 watermark-only CLI runs don't pay the TensorFlow / PyTorch startup cost.
 """
 
+# basedpyright cannot follow the __getattr__ (PEP 562) lazy-export hook below,
+# so it flags every name in __all__ as "not present in module" even though
+# __getattr__ resolves each one on first access. This is the documented
+# mechanism this module exists for (see module docstring); suppressing the
+# check here is correct, not a workaround for a real gap.
+# pyright: reportUnsupportedDunderAll=false
+
 __version__ = "0.1.0"
 __author__ = "Untextre Team"
 

--- a/untextre/cli.py
+++ b/untextre/cli.py
@@ -62,7 +62,7 @@ def main() -> None:
     
     # Start timing
     start_time = time.time()
-    detailed_timings = [] if args.timing else None
+    detailed_timings: List[dict] = []
     
     # Validate input path
     input_path = Path(args.input)

--- a/untextre/detector.py
+++ b/untextre/detector.py
@@ -25,9 +25,9 @@ logger = setup_logger(__name__)
 Detection = Dict[str, Any]  # {'geometry': points, 'confidence': score}
 
 # Module-level model instances for persistent loading
-_easyocr_reader: Optional[object] = None
+_easyocr_reader: Optional[Any] = None
 _east_net: Optional[Any] = None
-_yolo11x_model: Optional[object] = None
+_yolo11x_model: Optional[Any] = None
 
 EAST_MODEL_URL = "https://github.com/oyyd/frozen_east_text_detection.pb/raw/master/frozen_east_text_detection.pb"
 EAST_MODEL_DOCS = "docs/detector-models.md"
@@ -42,7 +42,7 @@ YOLO11X_MODEL_MIN_BYTES = 50 * 1024 * 1024
 
 
 
-def get_easyocr_reader() -> object:
+def get_easyocr_reader() -> Any:
     """Return the shared EasyOCR reader."""
     global _easyocr_reader
 
@@ -66,7 +66,7 @@ def get_east_net() -> Any:
 
     return _east_net
 
-def get_yolo11x_model() -> object:
+def get_yolo11x_model() -> Any:
     """Return the shared YOLO11x watermark detector."""
     global _yolo11x_model
 

--- a/untextre/detector_pair_harvest.py
+++ b/untextre/detector_pair_harvest.py
@@ -107,6 +107,8 @@ def summarize_detector_rows(detector: str, pairs: dict[str, dict], rows: list[di
 
     for row in clean_rows:
         pair_id = row.get("pair_id")
+        if pair_id is None:
+            continue
         boxes = row.get("boxes") or []
         if not boxes:
             continue
@@ -115,6 +117,8 @@ def summarize_detector_rows(detector: str, pairs: dict[str, dict], rows: list[di
 
     for row in twin_rows:
         pair_id = row.get("pair_id")
+        if pair_id is None:
+            continue
         boxes = row.get("boxes") or []
         if boxes:
             twin_fires.add(pair_id)

--- a/untextre/discovery.py
+++ b/untextre/discovery.py
@@ -7,7 +7,7 @@ images and returns BGRA crop(s) suitable for the -K / ORB pipeline.
 import cv2
 import numpy as np
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .utils import load_image, setup_logger
 from .watermark_consensus import (
@@ -298,7 +298,7 @@ def _normalize_01(arr: np.ndarray) -> np.ndarray:
     return (a - lo) / (hi - lo)
 
 
-def compute_stack_statistics(paths: List[Path]) -> Optional[Dict[str, np.ndarray]]:
+def compute_stack_statistics(paths: List[Path]) -> Optional[Dict[str, Any]]:
     """Compute per-pixel statistics across a set of same-size images.
 
     Uses Welford's online algorithm so memory scales with image size, not
@@ -335,6 +335,10 @@ def compute_stack_statistics(paths: List[Path]) -> Optional[Dict[str, np.ndarray
             gray_M2 = np.zeros_like(gray)
             bgr_mean = bgr.copy()
         else:
+            # gray_M2 and bgr_mean are always set together with gray_mean
+            # (all three assigned in the `if` branch above); this narrows
+            # them from Optional for the type checker.
+            assert gray_M2 is not None and bgr_mean is not None
             delta = gray - gray_mean
             gray_mean += delta / n
             gray_M2 += delta * (gray - gray_mean)
@@ -342,6 +346,9 @@ def compute_stack_statistics(paths: List[Path]) -> Optional[Dict[str, np.ndarray
 
     if n < 3:  # EMPIRICAL — minimum n for Welford variance; broader validation pending
         return None
+
+    # n >= 3 guarantees the loop set all three at least once.
+    assert gray_M2 is not None and bgr_mean is not None
 
     mean_bgr = bgr_mean.astype(np.uint8)
     var_gray = (gray_M2 / (n - 1)).astype(np.float32) if n > 1 else np.zeros_like(gray_M2, dtype=np.float32)
@@ -577,7 +584,7 @@ def score_to_mask(
     score: np.ndarray,
     var_norm: np.ndarray,
     precision_outlier_mask: Optional[np.ndarray] = None,
-) -> Dict[str, np.ndarray]:
+) -> Dict[str, Any]:
     """Produce the candidate mask from the composite score and stable-pixel region.
 
     The function has two responsibilities:
@@ -810,7 +817,7 @@ def extract_watermark_colors(
     log_max = float(log_var.max())
 
     if log_max - log_min > 1e-6:
-        log_var_u8 = cv2.normalize(log_var, None, 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)
+        log_var_u8 = cv2.normalize(log_var, np.empty_like(log_var, dtype=np.uint8), 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)
     else:
         log_var_u8 = np.zeros_like(log_var, dtype=np.uint8)
 
@@ -970,7 +977,7 @@ def discover_watermark_candidates(
 
         var_gray = stats["var_gray"]
         log_var = np.log10(var_gray.astype(np.float64) + 1e-8)
-        var_norm = cv2.normalize(log_var, None, 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)
+        var_norm = cv2.normalize(log_var, np.empty_like(log_var, dtype=np.uint8), 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)
 
         bucket_data[(img_w, img_h)] = (paths, stats, var_norm)
         all_log_prec.append(-log_var.flatten())
@@ -1070,7 +1077,7 @@ def discover_watermark_candidates(
             # Stable mask overlay debug image
             cv2.imwrite(str(debug_dir / f"debug_stable_mask_{stem}.png"), precision_mask)
             # Score with NORM_MINMAX so max always maps to 255 regardless of amplitude
-            score_vis = cv2.normalize(score, None, 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)
+            score_vis = cv2.normalize(score, np.empty_like(score, dtype=np.uint8), 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)
             cv2.imwrite(str(debug_dir / f"debug_score_{stem}.png"), score_vis)
             cv2.imwrite(str(debug_dir / f"debug_mask_raw_{stem}.png"), mask_data["mask_raw"])
             cv2.imwrite(str(debug_dir / f"debug_mask_clean_{stem}.png"), mask_data["mask_clean"])

--- a/untextre/find_text_colors.py
+++ b/untextre/find_text_colors.py
@@ -19,7 +19,7 @@ import cv2
 import numpy as np
 from typing import Optional
 
-from .utils import ImageArray, BBox, Color, setup_logger
+from .utils import ImageArray, BBox, Color, image_hw, setup_logger
 
 logger = setup_logger(__name__)
 
@@ -55,7 +55,7 @@ def html_to_bgr(html_color: str) -> Color:
     # Convert HTML name to hex using PIL
     from PIL import ImageColor
     rgb = ImageColor.getrgb(html_color)
-    return (rgb[2], rgb[1], rgb[0])  # Convert RGB to BGR
+    return (int(rgb[2]), int(rgb[1]), int(rgb[0]))  # Convert RGB to BGR
 
 
 def compute_cluster_fom(
@@ -160,7 +160,7 @@ def grabcut_refine(
         cv2.grabCut(
             image_roi,
             gc_mask,
-            None,  # rect unused when mask is provided
+            (0, 0, 0, 0),  # rect unused when mask is provided (GC_INIT_WITH_MASK)
             bgd_model,
             fgd_model,
             iterations,
@@ -336,7 +336,7 @@ def color_guided_expand(
     fgd_model = np.zeros((1, 65), np.float64)
 
     try:
-        cv2.grabCut(roi, gc_init, None, bgd_model, fgd_model,
+        cv2.grabCut(roi, gc_init, (0, 0, 0, 0), bgd_model, fgd_model,
                     iterations, cv2.GC_INIT_WITH_MASK)
     except cv2.error as e:
         if debug:
@@ -455,7 +455,7 @@ def geometry_budgeted_expand(
     """
     x, y, w, h = bbox
     bbox_area = max(w * h, 0)
-    x1, y1, x2, y2 = _expanded_bbox_roi(image.shape[:2], bbox, expand_factor)
+    x1, y1, x2, y2 = _expanded_bbox_roi(image_hw(image), bbox, expand_factor)
     roi_w = x2 - x1
     roi_h = y2 - y1
     if roi_w < 3 or roi_h < 3:
@@ -481,7 +481,7 @@ def geometry_budgeted_expand(
         cv2.grabCut(
             roi,
             gc_init,
-            None,
+            (0, 0, 0, 0),  # rect unused when mask is provided (GC_INIT_WITH_MASK)
             bgd_model,
             fgd_model,
             iterations,
@@ -570,7 +570,7 @@ def find_mask_by_spatial_tf_idf(
     cleanup_dilate_px: int = 13,
     use_grabcut: bool = False,
     return_cluster_data: bool = False,
-) -> np.ndarray:
+) -> np.ndarray | tuple[np.ndarray, dict]:
     """Create a binary mask using Figure of Merit analysis.
     
     This approach identifies text colors by computing a Figure of Merit (FOM)
@@ -680,7 +680,7 @@ def find_mask_by_spatial_tf_idf(
     _, labels, centers = cv2.kmeans(
         all_pixels_rgb.astype(np.float32), 
         num_clusters, 
-        None, 
+        np.zeros((all_pixels_rgb.shape[0], 1), dtype=np.int32),  # bestLabels ignored (KMEANS_PP_CENTERS)
         criteria, 
         10, 
         cv2.KMEANS_PP_CENTERS

--- a/untextre/inpaint.py
+++ b/untextre/inpaint.py
@@ -9,10 +9,15 @@ import cv2
 import gc
 import numpy as np
 import torch
-from typing import Optional, Tuple, Literal
+from typing import Optional, Tuple, Literal, TYPE_CHECKING
 
-from .utils import ImageArray, MaskArray, BBox, setup_logger, dilate_bbox, pad_bbox_to_multiple
+from .utils import ImageArray, MaskArray, BBox, image_hw, setup_logger, dilate_bbox, pad_bbox_to_multiple
 
+if TYPE_CHECKING:
+    # Type-only: the runtime import below may legitimately resolve to None
+    # when LaMa's dependencies aren't installed, so `LamaInpainter` isn't
+    # always a type at runtime and can't be used directly in annotations.
+    from .lama_inpainter import LamaInpainter as _LamaInpainterType
 
 try:
     from .lama_inpainter import LamaInpainter
@@ -174,7 +179,7 @@ def initialize_lama_model(device: str = "cuda", force_reinit: bool = False) -> b
         reset_lama_model()
         return False
 
-def get_lama_inpainter() -> Optional[LamaInpainter]:
+def get_lama_inpainter() -> "Optional[_LamaInpainterType]":
     """Get the cached LaMa inpainter instance.
     
     Returns:
@@ -253,13 +258,15 @@ def _inpaint_with_lama(
             logger.warning("LaMa model not initialized. Attempting auto-initialization...")
             if initialize_lama_model(device=_lama_device or "cuda"):
                 inpainter = get_lama_inpainter()
+                if inpainter is None:
+                    raise RuntimeError("LaMa model initialized but inpainter instance unavailable.")
             else:
                 raise RuntimeError("Failed to auto-initialize LaMa model.")
         else:
             raise RuntimeError("LaMa model not initialized. Call initialize_lama_model() first.")
     
     # Calculate subregion for efficient processing
-    subregion = _calculate_inpainting_subregion(mask, bbox, image.shape[:2])
+    subregion = _calculate_inpainting_subregion(mask, bbox, image_hw(image))
     
     # If no subregion found (no pixels to inpaint), return original image
     if subregion is None:
@@ -352,7 +359,7 @@ def _has_pixels_to_inpaint(mask: MaskArray) -> bool:
     Returns:
         True if there are pixels to inpaint (white pixels), False otherwise
     """
-    return np.any(mask > 0)
+    return bool(np.any(mask > 0))
 
 
 

--- a/untextre/lama_inpainter.py
+++ b/untextre/lama_inpainter.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import cv2  # OpenCV for colour space conversions
@@ -101,6 +101,11 @@ def paste_subregion(
 class LamaInpainter:  # pylint: disable=too-few-public-methods
     """Thin convenience wrapper around the SAIC-AI LaMa model."""
 
+    # Genuinely dynamic: either a SimpleLama instance (typed) or an
+    # original-LaMa-repo model object from the unstubbed `saicinpainting`
+    # package. No shared interface exists to type this more precisely.
+    model: Any
+
     def __init__(
         self,
         checkpoint_path: Optional[Path | str] = None,
@@ -134,6 +139,10 @@ class LamaInpainter:  # pylint: disable=too-few-public-methods
             self.model = SimpleLama()
         else:
             logger.info("Falling back to original LaMa repo loader on %s", self.device)
+            if load_checkpoint is None:
+                raise RuntimeError(
+                    "Neither simple-lama-inpainting nor the original LaMa repo is available."
+                )
             self.model = load_checkpoint(checkpoint_path, map_location=self.device)
             self.model.freeze()
             self.model.to(self.device)
@@ -267,10 +276,12 @@ class LamaInpainter:  # pylint: disable=too-few-public-methods
                 logger.debug(f"Input mask type: {type(mask)}, shape: {mask.shape}, dtype: {mask.dtype}")
                 out_rgb = self.model(img_rgb, mask)
                 logger.debug(f"SimpleLama output type: {type(out_rgb)}")
-                # SimpleLama returns PIL Image - convert to numpy array to maintain our API contract
-                if hasattr(out_rgb, 'convert'):  # Check if it's a PIL Image
-                    logger.debug("Converting PIL Image to numpy array")
-                    out_rgb = np.array(out_rgb)
+                # SimpleLama always returns a PIL Image (Image.fromarray(...) in its
+                # source); np.asarray() converts it to a real ndarray. Using asarray
+                # (not a conditional + np.array) also accepts any PIL-like duck type
+                # (anything implementing __array__, e.g. test doubles) without a
+                # brittle isinstance/hasattr check, and is a no-op if already ndarray.
+                out_rgb = np.asarray(out_rgb)
                 logger.debug(f"Final output type: {type(out_rgb)}, shape: {out_rgb.shape}, dtype: {out_rgb.dtype}")
                 
                 # CRITICAL: SimpleLama pads to mod-8, output is padded size

--- a/untextre/orb_matcher.py
+++ b/untextre/orb_matcher.py
@@ -90,7 +90,9 @@ def find_known_mask_in_image(
 
     target_gray = cv2.cvtColor(target_image, cv2.COLOR_BGR2GRAY)
     orb = create_orb_detector()
-    target_keypoints, target_descriptors = orb.detectAndCompute(target_gray, None)
+    target_keypoints, target_descriptors = orb.detectAndCompute(
+        target_gray, np.full(target_gray.shape, 255, dtype=np.uint8)
+    )
 
     if target_descriptors is None or target_keypoints is None:
         logger.warning("Could not compute target ORB descriptors")
@@ -136,8 +138,8 @@ def find_known_mask_in_image(
             logger.warning(f"Not enough good matches: {len(good_matches)} < {min_matches}")
             continue
 
-        src_pts = np.float32([known_keypoints[m.queryIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-        dst_pts = np.float32([target_keypoints[m.trainIdx].pt for m in good_matches]).reshape(-1, 1, 2)
+        src_pts = np.array([known_keypoints[m.queryIdx].pt for m in good_matches], dtype=np.float32).reshape(-1, 1, 2)
+        dst_pts = np.array([target_keypoints[m.trainIdx].pt for m in good_matches], dtype=np.float32).reshape(-1, 1, 2)
 
         M, inlier_mask = cv2.estimateAffine2D(
             src_pts,
@@ -201,7 +203,7 @@ def find_known_mask_in_image(
             (w_target, h_target),
             flags=cv2.INTER_LINEAR,
             borderMode=cv2.BORDER_CONSTANT,
-            borderValue=0,
+            borderValue=(0, 0, 0, 0),
         )
         _, binary_mask = cv2.threshold(warped_mask, 127, 255, cv2.THRESH_BINARY)
 

--- a/untextre/orb_prep.py
+++ b/untextre/orb_prep.py
@@ -33,7 +33,7 @@ class CandidateOrbVariant:
 
 
 def create_orb_detector() -> cv2.ORB:
-    return cv2.ORB_create(
+    return cv2.ORB.create(
         nfeatures=ORB_NFEATURES,
         edgeThreshold=ORB_EDGE_THRESHOLD,
         fastThreshold=ORB_FAST_THRESHOLD,
@@ -106,7 +106,7 @@ def prepare_candidate_for_orb(
             padding,
             padding,
             cv2.BORDER_CONSTANT,
-            value=0,
+            value=(0, 0, 0, 0),
         )
 
     prepared_gray = cv2.cvtColor(prepared_bgr, cv2.COLOR_BGR2GRAY)

--- a/untextre/pipeline.py
+++ b/untextre/pipeline.py
@@ -3,7 +3,7 @@
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, TYPE_CHECKING, Tuple
 
 import cv2
 import numpy as np
@@ -11,11 +11,18 @@ import numpy as np
 from .utils import (
     CLI_DEFAULT_CONFIDENCE,
     calculate_bbox_superset,
+    image_hw,
     load_image,
     pad_bbox_to_multiple,
     save_image,
     setup_logger,
 )
+
+if TYPE_CHECKING:
+    # Deferred: importing .inpaint eagerly would pull in torch at module load,
+    # defeating the lazy-loading this module is designed around (see the
+    # local `from .inpaint import inpaint_image` calls below). Type-only.
+    from .inpaint import InpaintMethod
 
 logger = setup_logger(__name__)
 
@@ -162,7 +169,7 @@ def _generate_masks_and_inpaint(
     image: np.ndarray,
     consensus_boxes: List[Tuple[int, int, int, int]],
     g_value: int,
-    method: str,
+    method: "InpaintMethod",
     target_color: Optional[tuple] = None,
     use_grabcut: bool = False,
     use_grabcut_expand: bool = False,
@@ -223,7 +230,7 @@ def _generate_masks_and_inpaint(
                 cleanup_close_px=mask_config.get("cleanup_close_px", 11),
                 cleanup_dilate_px=mask_config.get("cleanup_dilate_px", 13),
             )
-            if use_grabcut_expand or use_budgeted_expand:
+            if isinstance(mask_result, tuple):
                 region_mask, cluster_data = mask_result
             else:
                 region_mask = mask_result
@@ -285,7 +292,7 @@ def _generate_masks_and_inpaint(
 
     logger.info(f"Processed {regions_processed}/{len(consensus_boxes)} regions with g={g_value}")
 
-    inpaint_region = calculate_bbox_superset(consensus_boxes, image.shape[:2])
+    inpaint_region = calculate_bbox_superset(consensus_boxes, (h, w))
 
     total_image_pixels = h * w
     mask_pixel_count = int(np.sum(combined_mask > 0))
@@ -326,7 +333,7 @@ def process_image_array(
     *,
     image_name: str = "<memory>",
     target_color: Optional[tuple] = None,
-    method: str = "lama",
+    method: "InpaintMethod" = "lama",
     mask: Optional[np.ndarray] = None,
     confidence_threshold: float = CLI_DEFAULT_CONFIDENCE,
     granularity: Optional[int] = None,
@@ -410,7 +417,7 @@ def _process_image_array_impl(
     *,
     image_name: str = "<memory>",
     target_color: Optional[tuple] = None,
-    method: str = "lama",
+    method: "InpaintMethod" = "lama",
     mask: Optional[np.ndarray] = None,
     confidence_threshold: float = CLI_DEFAULT_CONFIDENCE,
     granularity: Optional[int] = None,
@@ -595,7 +602,7 @@ def _process_image_array_impl(
 
         # Inpaint using the loaded mask
         inpaint_start = time.time()
-        inpaint_region = calculate_bbox_superset(consensus_boxes, image.shape[:2])
+        inpaint_region = calculate_bbox_superset(consensus_boxes, image_hw(image))
         result = inpaint_image(image, mask, bbox=inpaint_region, method=method)
         timings['inpaint_time'] = time.time() - inpaint_start
     else:
@@ -661,7 +668,7 @@ def process_single_image(
     output_dir: Path,
     target_color: Optional[tuple] = None,
     keep_masks: bool = False,
-    method: str = "lama",
+    method: "InpaintMethod" = "lama",
     maskfile: Optional[str] = None,
     confidence_threshold: float = CLI_DEFAULT_CONFIDENCE,
     granularity: Optional[int] = None,

--- a/untextre/synthetic_text_benchmark.py
+++ b/untextre/synthetic_text_benchmark.py
@@ -19,7 +19,7 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 from .mask_experiments import MaskExperimentConfig, compute_mask_metrics
-from .pipeline import process_image_array
+from .pipeline import PipelineResult, process_image_array
 from .utils import load_image
 
 
@@ -178,7 +178,7 @@ def run_in_memory_watermark_benchmark(
     font_dirs: Sequence[Path] | None = None,
     image_loader: Callable[[Path], np.ndarray] = load_image,
     case_builder: Callable[..., SyntheticTextCase] | None = None,
-    process_image_fn: Callable[..., object] = process_image_array,
+    process_image_fn: Callable[..., PipelineResult] = process_image_array,
 ) -> list[dict]:
     """Run a reproducible synthetic watermark benchmark fully in memory."""
     base_dir = Path(base_dir)
@@ -490,9 +490,11 @@ def replay_synthetic_text_case(
     text = str(case["text"])
     font_path = Path(case["font_path"])
     font_size = int(case["font_size"])
-    fill_rgb = tuple(int(channel) for channel in case["color_rgb"])
+    fill_r, fill_g, fill_b = (int(channel) for channel in case["color_rgb"])
+    fill_rgb: tuple[int, int, int] = (fill_r, fill_g, fill_b)
     opacity = float(case["opacity"])
-    truth_bbox = tuple(int(value) for value in case["truth_bbox"])
+    bbox_x, bbox_y, bbox_w, bbox_h = (int(value) for value in case["truth_bbox"])
+    truth_bbox: tuple[int, int, int, int] = (bbox_x, bbox_y, bbox_w, bbox_h)
 
     outline_present = bool(case.get("outline_present", False))
     outline_thickness_px = int(case.get("outline_thickness_px", 0)) if outline_present else 0
@@ -728,7 +730,8 @@ def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:
 
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:
     value = value.lstrip("#")
-    return tuple(int(value[index:index + 2], 16) for index in (0, 2, 4))
+    r, g, b = (int(value[index:index + 2], 16) for index in (0, 2, 4))
+    return (r, g, b)
 
 
 def _summarize_corners(clean_bgr: np.ndarray) -> dict[str, dict]:
@@ -904,7 +907,12 @@ def _fit_text_mask(
 
     candidates.sort()
     font_size = candidates[0][1]
-    mask, local_bbox, raw_bbox, _ink_width = ink(font_size)
+    # font_size came from `candidates`, built only from sizes where ink()
+    # returned non-None (line 896); ink() memoizes by size, so this call
+    # returns that same cached, already-validated result.
+    info = ink(font_size)
+    assert info is not None
+    mask, local_bbox, raw_bbox, _ink_width = info
     return font_size, mask, local_bbox, raw_bbox
 
 

--- a/untextre/utils.py
+++ b/untextre/utils.py
@@ -13,7 +13,21 @@ ImageArray = np.ndarray  # H×W×3 BGR uint8
 MaskArray = np.ndarray   # H×W uint8
 Color = Tuple[int, int, int]  # BGR color tuple
 BBox = Tuple[int, int, int, int]  # (x, y, width, height)
+Shape2D = Tuple[int, int]  # (height, width)
 ImagePath = Union[str, Path]
+
+
+def image_hw(image: np.ndarray) -> Shape2D:
+    """Return an array's (height, width) as a concrete 2-tuple.
+
+    ``image.shape[:2]`` types as ``tuple[int, ...]`` under numpy's stubs
+    (shape's length isn't statically known), which callers typed
+    ``Tuple[int, int]`` reject. Unpacking into two names and rebuilding the
+    tuple narrows it correctly; use this instead of raw ``.shape[:2]``
+    wherever the result feeds a ``Shape2D``/``Tuple[int, int]`` parameter.
+    """
+    h, w = image.shape[:2]
+    return (h, w)
 
 # Supported image extensions
 IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.bmp', '.tiff', '.tif', '.webp'}

--- a/untextre/watermark_consensus.py
+++ b/untextre/watermark_consensus.py
@@ -6,7 +6,7 @@ import time
 
 import cv2
 import numpy as np
-from .utils import setup_logger
+from .utils import image_hw, setup_logger
 
 logger = setup_logger(__name__)
 
@@ -344,7 +344,7 @@ def split_candidate_bgra(
     }
 
     groups: list[set[int]] = [{label} for label in range(1, num_labels)]
-    canvas_shape = bgra.shape[:2]
+    canvas_shape = image_hw(bgra)
     changed = True
     while changed:
         changed = False
@@ -566,7 +566,7 @@ def _translate_image(img: np.ndarray, tx: float, ty: float, binary: bool = False
         (w, h),
         flags=interp,
         borderMode=cv2.BORDER_CONSTANT,
-        borderValue=0,
+        borderValue=(0, 0, 0, 0),
     )
 
 
@@ -744,8 +744,8 @@ def _evaluate_pairwise_scale(
     mov_alpha = _resize_image(mov.score_alpha_soft.astype(np.float32), float(working_scale))
 
     canvas_shape = _build_alignment_canvas_shape(
-        ref.score_distance_field.shape[:2],
-        mov_dist.shape[:2],
+        image_hw(ref.score_distance_field),
+        image_hw(mov_dist),
     )
 
     ref_dist_canvas, _, _ = _center_on_canvas(
@@ -766,7 +766,9 @@ def _evaluate_pairwise_scale(
         return None
 
     hann = _get_hann_window(canvas_shape)
-    (tx, ty), response = cv2.phaseCorrelate(ref_dist_canvas * hann, mov_dist_canvas * hann)
+    (tx, ty), response = cv2.phaseCorrelate(
+        (ref_dist_canvas * hann).astype(np.float64), (mov_dist_canvas * hann).astype(np.float64)
+    )
     aligned_support = _translate_image(mov_support_canvas, tx, ty, binary=True)
     aligned_alpha = _translate_image(mov_alpha_canvas, tx, ty, binary=False)
 
@@ -1219,7 +1221,7 @@ def _scaled_shape(shape: tuple[int, int], scale: float) -> tuple[int, int]:
 
 
 def _cluster_canvas_shape(graph: CandidateGraph, cluster: ClusterRecord) -> tuple[int, int]:
-    anchor_shape = graph.records[cluster.anchor_index].bgra.shape[:2]
+    anchor_shape = image_hw(graph.records[cluster.anchor_index].bgra)
     max_h, max_w = anchor_shape
     for member_index in cluster.member_indices:
         if member_index == cluster.anchor_index:
@@ -1228,7 +1230,7 @@ def _cluster_canvas_shape(graph: CandidateGraph, cluster: ClusterRecord) -> tupl
         if score is None:
             continue
         scaled_h, scaled_w = _scaled_shape(
-            graph.records[member_index].bgra.shape[:2],
+            image_hw(graph.records[member_index].bgra),
             score.scale,
         )
         max_h = max(max_h, scaled_h)


### PR DESCRIPTION
Closes #2.

## Decision (issue's own "Decision needed" #1)
Adopted the issue's own recommendation: **`untextre/` must pass basedpyright cleanly; `tests/`/`scripts/` remain unenforced for now.** `tests/`+`scripts/` still have 133 pre-existing errors — a much larger, lower-priority tier per the issue's own split between "production source errors (must fix)" and "test-file errors (fix or suppress with justification)". Filing a separate follow-up issue for that tier next so it stays tracked rather than silently dropped.

## Decision (issue's own "Decision needed" #2)
`uv run basedpyright untextre` now runs in CircleCI, right after Ruff and before the test step (fails fast, before spending CI time on the GPU-heavy detection suite).

## What was wrong (72 errors + 16 warnings) and how each class was fixed

- **`__init__.py` (16 warnings)** — `reportUnsupportedDunderAll` false-positive against the deliberate PEP 562 `__getattr__` lazy-export hook (documented in the module docstring, exists specifically to avoid TF/PyTorch import cost). Suppressed with a file-level pragma + comment explaining why; the lazy-loading itself is untouched.

- **Shape-tuple mismatches (10 sites: `pipeline.py`, `inpaint.py`, `find_text_colors.py`, `watermark_consensus.py`)** — `ndarray.shape[:2]` types as `tuple[int, ...]`, not the `tuple[int, int]` several helper signatures declare. Added `utils.image_hw()` (unpack-then-rebuild, which narrows correctly) and used it at each call site; reused already-unpacked `h, w` locals where already in scope instead of re-slicing.

- **`InpaintMethod` Literal propagation (`pipeline.py`)** — `method: str` widened to `method: InpaintMethod` across the four functions between the CLI's `argparse choices=['lama','telea']` and `inpaint_image()`. Imported `InpaintMethod` `TYPE_CHECKING`-only (quoted annotation) so `pipeline.py` doesn't eagerly import `.inpaint`'s `torch` dependency — preserves the module's existing lazy-import design.

- **Optional-narrowing gaps (`cli.py`, `inpaint.py`, `discovery.py`, `detector_pair_harvest.py`, `synthetic_text_benchmark.py`)** — each is a real spot where a compound condition or loop-carried invariant that keeps two variables' None-ness in sync isn't visible to flow analysis. Fixed with the narrowest correct tool per site: an explicit None-guard-and-continue/raise, an `assert` documenting the invariant, or (`cli.py`) removing the `Optional` entirely since `detailed_timings` only ever needed a truthiness check.

- **Loosely-typed lazy singletons (`detector.py` `get_easyocr_reader`/`get_yolo11x_model`, `synthetic_text_benchmark.py` `process_image_fn`)** — retyped from `object`/`object` to `Any`/`Callable[..., PipelineResult]` to match the already-established sibling pattern (`get_east_net`) and the actual default callable's real return type.

- **cv2 stub gaps** where the runtime idiom isn't in the stub's overload set: `grabCut`'s `rect` (unused in `GC_INIT_WITH_MASK` mode — `None` → inert `(0,0,0,0)`), `warpAffine`/`copyMakeBorder`'s `borderValue`/`value` (`0` → `(0,0,0,0)`, behaviorally identical scalar fill), `kmeans`' `bestLabels` (`KMEANS_PP_CENTERS` ignores initial content — `None` → same-shape dummy buffer), `normalize`'s `dst` (`None` → pre-allocated same-shape array; cv2 always returns the computed array either way).

- **`cv2.ORB_create` → `cv2.ORB.create` (`orb_prep.py`)** — the legacy module-level factory isn't in the stub; `ORB.create` is the identical, stub-recognized equivalent (verified). Required updating one test's monkeypatch target and its mask-argument assertion, since `find_known_mask_in_image`'s `detectAndCompute` call also switched from `mask=None` to an explicit all-255 mask (same cv2-stub-gap fix as above) — the test previously asserted the mask was `None`.

- **`lama_inpainter.py`** — `self.model` declared `Any` (it's genuinely either a typed `SimpleLama` instance or an unstubbed original-LaMa-repo object, with no shared interface — `Any` is the honest type). The SimpleLama-output-to-ndarray conversion changed from a conditional `hasattr(x, 'convert')` + `np.array()` to an unconditional `np.asarray(x)` — `SimpleLama`'s source always returns `Image.fromarray(...)`, so this is behavior-preserving and also accepts any duck-typed test double implementing `__array__` without a brittle `isinstance`/`hasattr` check. (An earlier `isinstance`-based attempt broke exactly such a test double in `test_lama_inpainter.py`; caught by the test suite and reverted in favor of this before landing.)

- **Generator-built tuples that don't narrow to fixed arity** (`find_text_colors.html_to_bgr`, `synthetic_text_benchmark._hex_to_rgb`/`replay_synthetic_text_case`) — explicit unpack-then-rebuild instead of `tuple(generator)`.

- **`find_mask_by_spatial_tf_idf`'s return type** widened from `np.ndarray` to `np.ndarray | tuple[np.ndarray, dict]` to match its actual dual-return contract (`return_cluster_data=True/False`); `pipeline.py`'s consumer switched from trusting a separately-tracked boolean to `isinstance(mask_result, tuple)`, which properly narrows the union.

## Verification
- `uv run basedpyright untextre` — 0 errors, 0 warnings, 0 notes
- `uv run ruff check untextre tests scripts` — clean
- `uv run pytest -m "not slow"` — 373 passed, 2 skipped, 24 deselected
- Targeted reruns after each file's fixes (`test_reports`, `test_cli`, `test_inpaint`, `test_lama_inpainter`, `test_discovery`, `test_pipeline`, `test_find_text_colors`, `test_orb_matcher`, `test_orb_prep`, `test_generated_text_benchmark`, `test_generated_text_cases`, `test_watermark_fixtures`) all green before the final full-suite pass
- Verified `uv sync --extra dev --extra web --frozen` (CI's exact install command) installs `basedpyright` via the default `dependency-groups.dev` group — no `pyproject.toml` change needed for CI to have it available