### PR TITLE
fix: keep phaseCorrelate on float32 in watermark consensus hot path

### DIFF
--- a/untextre/watermark_consensus.py
+++ b/untextre/watermark_consensus.py
@@ -765,10 +765,10 @@ def _evaluate_pairwise_scale(
     if np.max(mov_dist_canvas) < 1e-6:
         return None
 
-    hann = _get_hann_window(canvas_shape)
-    (tx, ty), response = cv2.phaseCorrelate(
-        (ref_dist_canvas * hann).astype(np.float64), (mov_dist_canvas * hann).astype(np.float64)
-    )
+    hann = _get_hann_window(canvas_shape).astype(np.float32, copy=False)
+    ref_phase = np.multiply(ref_dist_canvas, hann, dtype=np.float32)
+    mov_phase = np.multiply(mov_dist_canvas, hann, dtype=np.float32)
+    (tx, ty), response = cv2.phaseCorrelate(ref_phase, mov_phase)
     aligned_support = _translate_image(mov_support_canvas, tx, ty, binary=True)
     aligned_alpha = _translate_image(mov_alpha_canvas, tx, ty, binary=False)
 


### PR DESCRIPTION
## Problem
The #2 basedpyright cleanup made one behavioral change in `watermark_consensus.py` that regressed `-U` unknown-watermark mode on a real directory.

To satisfy the cv2 stub at `phaseCorrelate(...)`, the code widened the two phase-correlation inputs to `float64`:

```py
(tx, ty), response = cv2.phaseCorrelate(
    (ref_dist_canvas * hann).astype(np.float64),
    (mov_dist_canvas * hann).astype(np.float64),
)
```

That doubled the working set in the hottest pairwise-alignment path.

## Real repro
From repo root:

```powershell
uv run untextre `
  -i "G:\Documents and Settings\Jurph\Old\My Pictures\Zero\has-PZ-logo" `
  -o ".codex-tmp\u-mode-oom-check" `
  -U `
  --device cuda
```

Before this fix, that repro died at `watermark_consensus.py:769` with:

- `cv2.error: ... OutOfMemoryError`
- `Failed to allocate 62208000 bytes`

## Change
Keep this path on `float32` and make the dtype explicit without widening:

```py
hann = _get_hann_window(canvas_shape).astype(np.float32, copy=False)
ref_phase = np.multiply(ref_dist_canvas, hann, dtype=np.float32)
mov_phase = np.multiply(mov_dist_canvas, hann, dtype=np.float32)
(tx, ty), response = cv2.phaseCorrelate(ref_phase, mov_phase)
```

## Scope
This PR is intentionally narrow. It removes the regression introduced by #2.

It does **not** claim to solve the deeper `-U` memory ceiling: after this fix,
the exact same real-world repro gets past the old `phaseCorrelate` crash site
and then OOMs later in `_alignment_metrics()` on a much smaller bool
allocation. That proves there is a second, still-open memory-pressure problem
in `watermark_consensus`, but it is not this regression.

## Verification
- `uv run basedpyright untextre/watermark_consensus.py` — OK
- exact real-world `-U` repro above now advances past the old `phaseCorrelate`
  OOM site and fails later, proving this regression is removed even though the
  larger memory issue remains

## Why merge this now?
Because it cleanly removes the thing we know we broke, making the remaining
problem smaller and correctly localized for the next pass.