### PR TITLE
perf: stop caching per-scale Hann windows in watermark consensus

### DIFF
--- a/untextre/watermark_consensus.py
+++ b/untextre/watermark_consensus.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import lru_cache
 import time
 
 import cv2
@@ -550,8 +549,15 @@ def _build_alignment_canvas_shape(
     )
 
 
-@lru_cache(maxsize=128)
 def _get_hann_window(canvas_shape: tuple[int, int]) -> np.ndarray:
+    """Build the per-canvas Hann window used by phase correlation.
+
+    Do not cache these globally. The fallback scale ladder can visit dozens of
+    distinct canvas shapes per candidate pair, and a candidate graph visits many
+    pairs; an LRU cache here retains large float32 arrays whose total size can
+    dominate the process RSS and OOM otherwise-viable runs. The window is cheap
+    to rebuild relative to the pairwise alignment work around it.
+    """
     canvas_h, canvas_w = canvas_shape
     return cv2.createHanningWindow((canvas_w, canvas_h), cv2.CV_32F)
 


### PR DESCRIPTION
## Problem
PR #40 removed the narrow `float64` regression in `phaseCorrelate`, but the real `-U` repro still OOMed later in the same consensus-graph / alignment path.

Real repro:

```powershell
uv run untextre `
  -i "G:\Documents and Settings\Jurph\Old\My Pictures\Zero\has-PZ-logo" `
  -o ".codex-tmp\u-mode-oom-check" `
  -U `
  --device cuda
```

After PR #40, that got past the old `phaseCorrelate` OOM site and then still died deeper in watermark consensus.

## Minimized red loop
This is the tight loop that reproduced the remaining memory problem without the full CLI:

```powershell
uv run pytest tests/test_watermark_consensus.py::test_build_candidate_graph_isolates_noise_node -q
```

It went red with an OOM inside candidate-graph scoring.

## Diagnosis
The winning hypothesis was **cache retention**, not one giant single allocation.

A falsifying probe confirmed it:
- monkeypatch `_get_hann_window` to its undecorated implementation (`.__wrapped__`)
- rerun the minimized red loop
- it goes green immediately

Instrumentation on the minimized 4-record graph showed:
- 12 directional pairs
- 117 distinct canvas shapes visited by the fallback scale ladder
- ~135 MB retained in Hann windows **alone**

The culprit was:

```py
@lru_cache(maxsize=128)
def _get_hann_window(...):
```

That looks harmless in isolation, but `score_candidate_pair()` visits many scales per pair and `build_candidate_graph()` visits many pairs, so the cache ends up retaining a large pile of full-size float32 images.

## Change
Remove the `lru_cache` from `_get_hann_window` and document why caching is actively harmful here.

This keeps correctness unchanged and trades a cheap recomputation for a large reduction in retained RSS.

## Verification
- `uv run pytest tests/test_watermark_consensus.py::test_build_candidate_graph_isolates_noise_node -q` — passed (was the minimized red loop)
- `uv run pytest tests/test_watermark_consensus.py tests/test_watermark_consensus_fixtures.py -m "not slow"` — 16 passed, 2 deselected
- `uv run basedpyright untextre` — OK
- `uv run ruff check untextre tests scripts` — OK
- exact real-world `-U` repro against `has-PZ-logo` now gets through:
  - watermark discovery
  - consensus graph construction
  - candidate export
  - model initialization
  - and well into per-image ORB + LaMa processing

On the local 180s harness it no longer OOMs in `watermark_consensus`; the timeout hit while processing image 16/37, which is a throughput/runtime limit of the harness, not the old memory failure.