### PR TITLE
perf: reuse target ORB features across known-mask templates (#8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,27 @@ Zoom in: see the graphite on the paper, the individual fibers, the motes of carb
 Zoom out: see the patterns across files, across modules, across the landscape. The order should be visible at every scale.
 
 Seek order by drawing the correct figures; zoom out and perceive the truth of the binary.
+
+## GitHub MCP Tool Quirk
+
+When using the GitHub MCP comment tool, be careful to keep **comment-body**
+calls and **reaction-to-existing-comment** calls separate.
+
+- A plain issue/PR comment should send **only** a body plus the target issue/PR.
+- A reaction should send the target `comment_id` plus the reaction, **without**
+  a body.
+
+Observed failure mode on 2026-07-11:
+
+- The MCP layer rejected mixed-shape calls with:
+  `comment_id cannot be combined with body`
+- Repeating the same malformed call can trap the agent in a retry loop.
+
+Safe workaround:
+
+- If the comment tool starts insisting on `comment_id`/reaction-shaped args while
+  you are trying to leave a plain text comment, stop retrying it.
+- For simple close/restate/update operations, use the GitHub issue/PR **update**
+  path instead of the comment path for that turn.
+
+This is a tooling quirk, not a repo-code problem.

--- a/TODO.md
+++ b/TODO.md
@@ -58,9 +58,9 @@ so this file never drifts from the tracker.
 - [x] **Consensus padding label**: Add `# EMPIRICAL` label to the 10%-per-side
   padding constant. `(consensus.py:397-417)`
 
-- [ ] **process_with_known_mask API** (#8): Document (or add a `WatermarkTemplate`
-  overload to) `process_with_known_mask` so batch callers are not forced into
-  O(N×templates) ORB extraction. `(orb_matcher.py:93)`
+- [x] **process_with_known_mask API** (#8): Added reusable target-ORB feature
+  preparation so multi-template known-mask cascades extract the target image’s
+  ORB keypoints/descriptors once per image instead of once per template.
 
 ---
 

--- a/tests/test_orb_matcher.py
+++ b/tests/test_orb_matcher.py
@@ -88,6 +88,7 @@ class TestTryWatermarkCascade:
             min_matches=6,
             dilation_pixels=7,
             prepared_variants=None,
+            prepared_target=None,
         ):
             calls.append((min_matches, dilation_pixels))
             if len(calls) == 1:
@@ -96,13 +97,16 @@ class TestTryWatermarkCascade:
                 return mask_b, bbox_b, 5  # b: weak match
             if len(calls) == 3:
                 return mask_c, bbox_c, 10 # c: stronger match — should win
-
+        monkeypatch.setattr(
+            orb_matcher_mod,
+            "prepare_target_orb_features",
+            lambda _image: (tuple(), np.ones((1, 32), dtype=np.uint8)),
+        )
         monkeypatch.setattr(
             orb_matcher_mod,
             "find_known_mask_in_image",
             fake_find_known_mask_in_image,
         )
-
         result = try_watermark_cascade(image, templates, min_matches=9, dilation_pixels=5)
 
         assert result is not None
@@ -112,6 +116,48 @@ class TestTryWatermarkCascade:
         assert bbox == bbox_c
         assert len(calls) == 3, "All three templates must be tried"
         assert calls == [(9, 5), (9, 5), (9, 5)]
+ 
+    def test_target_orb_extracted_once_for_multi_template_input(self, monkeypatch):
+        image = np.zeros((60, 60, 3), dtype=np.uint8)
+        templates = [
+            WatermarkTemplate("a.png", np.zeros((8, 8, 4), dtype=np.uint8), ()),
+            WatermarkTemplate("b.png", np.zeros((8, 8, 4), dtype=np.uint8), ()),
+            WatermarkTemplate("c.png", np.zeros((8, 8, 4), dtype=np.uint8), ()),
+        ]
+        prepared_target = (tuple(), np.ones((1, 32), dtype=np.uint8))
+        prepare_calls = []
+        find_calls = []
+ 
+        def fake_prepare_target_orb_features(_image):
+            prepare_calls.append("called")
+            return prepared_target
+ 
+        def fake_find_known_mask_in_image(
+            _image,
+            _tmpl,
+            min_matches=6,
+            dilation_pixels=15,
+            prepared_variants=None,
+            prepared_target=None,
+        ):
+            find_calls.append(prepared_target)
+            return None
+ 
+        monkeypatch.setattr(
+            orb_matcher_mod,
+            "prepare_target_orb_features",
+            fake_prepare_target_orb_features,
+        )
+        monkeypatch.setattr(
+            orb_matcher_mod,
+            "find_known_mask_in_image",
+            fake_find_known_mask_in_image,
+        )
+ 
+        assert try_watermark_cascade(image, templates) is None
+        assert prepare_calls == ["called"]
+        assert len(find_calls) == 3
+        assert all(call is prepared_target for call in find_calls)
 
 
 class TestFindKnownMaskValidation:

--- a/untextre/orb_matcher.py
+++ b/untextre/orb_matcher.py
@@ -23,6 +23,22 @@ class WatermarkTemplate:
     orb_variants: tuple[CandidateOrbVariant, ...]
 
 
+
+PreparedTargetOrb = Tuple[tuple[cv2.KeyPoint, ...], np.ndarray]
+
+
+def prepare_target_orb_features(target_image: np.ndarray) -> Optional[PreparedTargetOrb]:
+    """Extract ORB features for one target image once, for reuse across templates."""
+    target_gray = cv2.cvtColor(target_image, cv2.COLOR_BGR2GRAY)
+    orb = create_orb_detector()
+    target_keypoints, target_descriptors = orb.detectAndCompute(
+        target_gray, np.full(target_gray.shape, 255, dtype=np.uint8)
+    )
+    if target_descriptors is None or target_keypoints is None:
+        logger.warning("Could not compute target ORB descriptors")
+        return None
+    return tuple(target_keypoints), target_descriptors
+
 def _make_watermark_template(name: str, rgba: np.ndarray) -> WatermarkTemplate:
     return WatermarkTemplate(name, rgba, tuple(build_candidate_orb_variants(rgba)))
 
@@ -78,6 +94,7 @@ def find_known_mask_in_image(
     min_matches: int = 6,
     dilation_pixels: int = 15,
     prepared_variants: Optional[tuple[CandidateOrbVariant, ...]] = None,
+    prepared_target: Optional[PreparedTargetOrb] = None,
 ) -> Optional[Tuple[np.ndarray, Tuple[int, int, int, int], int]]:
     """Find a known watermark/logo by trying precomputed ORB reference variants."""
     if known_mask_rgba.shape[2] != 4:
@@ -88,15 +105,11 @@ def find_known_mask_in_image(
         logger.warning("No ORB variants available for known mask")
         return None
 
-    target_gray = cv2.cvtColor(target_image, cv2.COLOR_BGR2GRAY)
-    orb = create_orb_detector()
-    target_keypoints, target_descriptors = orb.detectAndCompute(
-        target_gray, np.full(target_gray.shape, 255, dtype=np.uint8)
-    )
-
-    if target_descriptors is None or target_keypoints is None:
-        logger.warning("Could not compute target ORB descriptors")
+    prepared_target = prepared_target or prepare_target_orb_features(target_image)
+    if prepared_target is None:
         return None
+
+    target_keypoints, target_descriptors = prepared_target
 
     if len(target_keypoints) < min_matches:
         logger.warning(
@@ -285,6 +298,14 @@ def try_watermark_cascade(
     best: Optional[Tuple[np.ndarray, Tuple[int, int, int, int], str]] = None
     best_inliers = -1
 
+    if not templates:
+        logger.info("No template matched (tried 0)")
+        return None
+
+    prepared_target = prepare_target_orb_features(image)
+    if prepared_target is None:
+        return None
+
     for template in templates:
         tmpl_name = template.name
         logger.info(f"Trying template: {tmpl_name}")
@@ -293,6 +314,7 @@ def try_watermark_cascade(
             min_matches=min_matches,
             dilation_pixels=dilation_pixels,
             prepared_variants=template.orb_variants,
+            prepared_target=prepared_target,
         )
         if result is not None:
             mask, bbox, inliers = result


### PR DESCRIPTION
Closes #8.

## Problem
`try_watermark_cascade(image, templates)` called `find_known_mask_in_image()` once per template, and each call re-extracted the target image's ORB keypoints/descriptors from scratch. With `N` templates against one image, target-side extraction was effectively `O(N)` even though the target image never changes inside the cascade.

## Change
- added `prepare_target_orb_features(target_image) -> Optional[PreparedTargetOrb]`
- extended `find_known_mask_in_image(..., prepared_target=None)` so callers can reuse a precomputed target feature set
- changed `try_watermark_cascade()` to compute `prepared_target` once per image and pass it into each template match
- kept the public `try_watermark_cascade()` signature unchanged
- updated `TODO.md`'s `#8` entry in the same branch so the repo's second source of truth stays aligned with the code

## Behavior
- empty-template cascades still return `None` without touching the image
- if target ORB extraction fails, the cascade now returns `None` once up front instead of rediscovering that same failure separately for every template

## Verification
- `uv run basedpyright untextre/orb_matcher.py` — OK
- `uv run ruff check untextre/orb_matcher.py tests/test_orb_matcher.py` — OK
- `uv run pytest tests/test_orb_matcher.py tests/test_cli.py tests/test_u_mode_integration.py tests/test_watermark_fixtures.py -m "not slow"` — 36 passed, 7 deselected
- new regression test proves target ORB extraction happens once for multi-template input and the same prepared target object is reused across all template calls

## Separate docs commit on this branch
This branch also includes a small local-only agent-facing docs commit (`CLAUDE.md`) recording the GitHub MCP `comment_id cannot be combined with body` tool quirk and its workaround. That note is intentionally separate from the `#8` code change in git history, but bundled on the same branch because it was requested in the same session.