### PR TITLE
fix: force_output reuses already-loaded image instead of reloading (#10)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -70,10 +70,10 @@ so this file never drifts from the tracker.
   `_try_color_enhanced_detection` invocations into a single helper that tries all
   colors in one pass with early exit. `(pipeline.py:87-121)`
 
-- [ ] **force_output double-load** (#10): When `image is not None` in the `force_output`
-  path, use the already-loaded image instead of reloading from disk. Requires a
-  conditional (not a one-line swap — `image` is `None` in the no-templates path).
-  `(cli.py:254-260)`
+- [x] **force_output double-load** (#10): `force_output` now reuses the already-loaded
+  `image` array from the template-cascade path instead of reloading from disk; falls
+  back to `load_image(image_path)` only when no image was loaded (no-templates path).
+  `(cli.py:239)`
 
 - [ ] **LaMa health check cost** (#17): Replace the full forward-pass health check with a
   cheaper attribute-existence check. `(inpaint.py:47-78)`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,6 +204,39 @@ class TestMainIntegrationPaths:
         assert any("_clean" in str(p) for p in saved.keys())
         assert all(source_path is not None for _arr, source_path in saved.values())
 
+    def test_force_output_reuses_already_loaded_image(self, monkeypatch, tmp_path):
+        """force_output must not reload the image when the template cascade already loaded it (#10)."""
+        img_path, out_dir = self._run_main(monkeypatch, tmp_path, ["--force-output"])
+
+        fake_template = orb_matcher_mod.WatermarkTemplate(
+            "fake.png", np.zeros((4, 4, 4), dtype=np.uint8), ()
+        )
+        monkeypatch.setattr(
+            orb_matcher_mod, "load_watermark_templates",
+            lambda *_a, **_kw: [fake_template],
+        )
+        monkeypatch.setattr(orb_matcher_mod, "try_watermark_cascade", lambda *_a, **_kw: None)
+        monkeypatch.setattr(
+            pipeline_mod, "process_single_image",
+            lambda **kw: {"total_time": 0.1, "skipped": True},
+        )
+        monkeypatch.setattr(cli_mod, "save_image", lambda *_a, **_kw: None)
+
+        load_calls = []
+        real_load_image = cli_mod.load_image
+
+        def tracking_load_image(path):
+            load_calls.append(path)
+            return real_load_image(path)
+
+        monkeypatch.setattr(cli_mod, "load_image", tracking_load_image)
+
+        main()
+
+        # The template cascade already loaded the image (line ~187); force_output
+        # must reuse that array instead of calling load_image a second time.
+        assert load_calls == [img_path]
+
 
     def test_timing_flag_saves_report(self, monkeypatch, tmp_path):
         """--timing produces timing_report.txt."""

--- a/untextre/cli.py
+++ b/untextre/cli.py
@@ -236,7 +236,7 @@ def main() -> None:
                 if args.force_output:
                     # Copy the original unchanged so every input has output
                     output_file = output_path / f"{image_path.stem}_clean{image_path.suffix}"
-                    save_image(load_image(image_path), output_file, source_path=image_path)
+                    save_image(image if image is not None else load_image(image_path), output_file, source_path=image_path)
                     logger.info(f"No text detected - copied original to {output_file}")
                 else:
                     logger.info(f"Skipped {image_path.name} (no text detected)")


### PR DESCRIPTION
Closes #10.

## Problem
When watermark templates load the image at `cli.py:187` (`image = load_image(image_path)`) and the template cascade finds no match, the code falls through to consensus detection. If that returns `skipped=True` and `--force-output` is set, the `force_output` branch called `load_image(image_path)` again instead of reusing the array already sitting in `image`.

## Fix
```python
save_image(image if image is not None else load_image(image_path), output_file, source_path=image_path)
```

`image` is `None` only in the no-templates path (`watermark_templates` empty), where `load_image` is still required since nothing loaded the file yet. When templates were tried, `image` already holds the loaded array regardless of whether the cascade matched.

## Verification
- `uv run basedpyright untextre/cli.py` — OK
- `uv run ruff check untextre/cli.py tests/test_cli.py` — OK
- `uv run pytest tests/test_cli.py -m "not slow"` — 14 passed
- new regression test `test_force_output_reuses_already_loaded_image` tracks `cli.load_image` call sites and asserts it's called **exactly once** per image when a template cascade already loaded it
  - confirmed this test goes **red** against the pre-fix code (verified via a temporary `git stash` of the fix)
  - confirmed **green** with the fix applied
- existing `test_force_output_copies_original` continues to pass unchanged

This matches the acceptance criteria from the issue: "`force_output` never calls `load_image` when `image` is already loaded; confirmed by adding an assertion or mock that `load_image` is called at most once per image in this path."